### PR TITLE
Updated Format-SpectreTable.ps1 to support Markup.

### DIFF
--- a/PwshSpectreConsole/public/formatting/Format-SpectreTable.ps1
+++ b/PwshSpectreConsole/public/formatting/Format-SpectreTable.ps1
@@ -1,4 +1,5 @@
 using module "..\..\private\completions\Completers.psm1"
+using namespace Spectre.Console
 
 function Format-SpectreTable {
     <#
@@ -50,9 +51,9 @@ function Format-SpectreTable {
         [String]$Title
     )
     begin {
-        $table = [Spectre.Console.Table]::new()
-        $table.Border = [Spectre.Console.TableBorder]::$Border
-        $table.BorderStyle = [Spectre.Console.Style]::new(($Color | Convert-ToSpectreColor))
+        $table = [Table]::new()
+        $table.Border = [TableBorder]::$Border
+        $table.BorderStyle = [Style]::new(($Color | Convert-ToSpectreColor))
         $headerProcessed = $false
         if ($Width) {
             $table.Width = $Width
@@ -61,7 +62,7 @@ function Format-SpectreTable {
             $table.ShowHeaders = $false
         }
         if ($Title) {
-            $table.Title = [Spectre.Console.TableTitle]::new($Title, [Spectre.Console.Style]::new(($Color | Convert-ToSpectreColor)))
+            $table.Title = [TableTitle]::new($Title, [Style]::new(($Color | Convert-ToSpectreColor)))
         }
     }
     process {
@@ -76,13 +77,13 @@ function Format-SpectreTable {
             $row = $_.psobject.Properties | ForEach-Object {
                 $cell = $_.Value
                 if ($null -eq $cell) {
-                    [Spectre.Console.Text]::new("")
+                    [Markup]::new("")
                 }
                 else {
-                    [Spectre.Console.Text]::new($cell.ToString())
+                    [Markup]::new($cell.ToString())
                 }
             }
-            $table = [Spectre.Console.TableExtensions]::AddRow($table, [Spectre.Console.Text[]]$row)
+            $table = [TableExtensions]::AddRow($table, [Markup[]]$row)
         }
     }
     end {


### PR DESCRIPTION
Currently color markup isn't parsed.

```
$data = @(
    [pscustomobject]@{Value="This is [red]colored[/] text"; Value2="This is [white]white[/] text"; }
    [pscustomobject]@{Value="This is more [green]colored text[/]"; Value2="This is normal text"; } 
)
Format-SpectreTable -Data $data -Color Grey30 -Border Square -Width 95 -HideHeaders
```

The above doesn't work currently. The table text isn't treated as markup, so any custom color tags won't work. This is how the above renders now:

![Code_CDVlZtKz8f](https://github.com/fmotion1/PwshSpectreConsole/assets/33441569/59e045bc-b36a-4e58-82e1-a5ca0802681d)

This commit fixes that problem. This is how the same code renders with my change:

![Code_AurGirZzkJ](https://github.com/fmotion1/PwshSpectreConsole/assets/33441569/141d320b-05e1-4c23-8480-62ce30e75ba7)

I've also added `using namespace Spectre.Console` at the top of the file to simplify object definitions in the body of the code.

Let me know if this change works for you.